### PR TITLE
Removing references to hydration exceptions as events

### DIFF
--- a/src/Bravo3/OrmBundle/DependencyInjection/Configuration.php
+++ b/src/Bravo3/OrmBundle/DependencyInjection/Configuration.php
@@ -49,9 +49,6 @@ class Configuration implements ConfigurationInterface
                 ->isRequired()
                 ->requiresAtLeastOneElement()
                 ->prototype('scalar')->end()
-                ->end()
-            ->booleanNode('hydration_exceptions_as_events')
-                ->defaultValue(false)
                 ->end();
 
         return $treeBuilder;

--- a/src/Bravo3/OrmBundle/DependencyInjection/OrmExtension.php
+++ b/src/Bravo3/OrmBundle/DependencyInjection/OrmExtension.php
@@ -37,8 +37,6 @@ class OrmExtension extends Extension
             $em->setFactory([self::ORM_FACT_CLASS, self::ORM_FACT_METHOD]);
         }
 
-        $em->addArgument($config['hydration_exceptions_as_events']);
-
         $container->getDefinition('orm.driver')
                   ->addArgument($config['params'])
                   ->addArgument($config['options'])

--- a/src/Bravo3/OrmBundle/Services/Factories/OrmFactory.php
+++ b/src/Bravo3/OrmBundle/Services/Factories/OrmFactory.php
@@ -13,18 +13,15 @@ class OrmFactory
      *
      * @param DriverInterface $driver
      * @param string          $cache_dir
-     * @param bool            $hydration_exceptions_as_events
      * @return EntityManager
      */
     public static function createEntityManager(
         DriverInterface $driver,
-        $cache_dir,
-        $hydration_exceptions_as_events = false
+        $cache_dir
     ) {
         $mapper = new AnnotationMapper();
         $config = new Configuration();
         $config->setCacheDir($cache_dir);
-        $config->setHydrationExceptionsAsEvents($hydration_exceptions_as_events);
         return EntityManager::build($driver, $mapper, null, null, $config);
     }
 }


### PR DESCRIPTION
These changes coincide with some underlying changes in the orm itself.
